### PR TITLE
[WEB-6684] POST to the API ignores all but the first element of the POST data

### DIFF
--- a/TribeHRConnector.php
+++ b/TribeHRConnector.php
@@ -136,9 +136,10 @@ class TribeHRConnector
       return $data;
     }
 
-    // Take our array and run http_build_query over it.
     // This will generate a cURL-compatible request that maps nicely to a multidimensional array on reception.
-    return http_build_query($data);
+    // The optional 2nd and 3rd arguments to http_build_query() are needed to fix inconsistencies 
+    // when running PHP in other server environments. (see: WEB-6684)
+    return http_build_query($data, '', '&');
   }
 
   /**
@@ -165,5 +166,3 @@ class TribeHRConnector
     return (substr($data, 0, 1) == '@');
   }
 }
-
-?>


### PR DESCRIPTION
Read the Jira story to familiarize with the problem as described by the customer, marsdd.

https://tribehr.atlassian.net/browse/WEB-6684

data is POSTed to the API like this:

```
a=1&b=2&c=3
```

Some servers will HTML-encode the default separator ("&") in http_build_query(). In those server environments, the resulting querystring will become:

```
a=1&amp;b=2&amp;c=3
```

See: http://php.net/manual/en/function.http-build-query.php#102324

Since "`amp;b`" is not the name of a field, it doesn't get saved. Consequently, any time the customer was POSTing to the API, it would save whichever field was first in the data array, and ignore the rest.

Because it's a glitch in PHP itself, you will not be able to reproduce this problem on any of our Linux-based servers. It doesn't happen - Phil The Bugmaster tried and tried and was never able to reproduce it. The customer, marsdd, experienced it consistently. 

Marsdd has already made this change in their own copy, and it fixed the problem.

QED
